### PR TITLE
check if blurRadius is <= 0.0f in applyBlurOnImage

### DIFF
--- a/LiveBlur/LiveBlur/DKLiveBlurView.m
+++ b/LiveBlur/LiveBlur/DKLiveBlurView.m
@@ -73,7 +73,7 @@
 
 - (UIImage *)applyBlurOnImage: (UIImage *)imageToBlur
                    withRadius:(CGFloat)blurRadius {
-    if ((blurRadius < 0.0f) || (blurRadius > 1.0f)) {
+    if ((blurRadius <= 0.0f) || (blurRadius > 1.0f)) {
         blurRadius = 0.5f;
     }
     


### PR DESCRIPTION
If blurRadius comes into **applyBlurOnImage** as exactly 0.0f for whatever reason (including in my case, explictly setting it to that, **vImageBoxConvolve_ARGB8888** will throw an **EXC_BAD_ACCESS** error, as boxSize is set to -1.
